### PR TITLE
fix/factor-out graphviz identifier encoding

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,11 +5,7 @@
   :dependencies [[org.clojure/clojure "1.10.1"]]
   :deploy-repositories [["snapshots" :clojars] ["releases" :clojars]]
   :pedantic? :abort
-  :profiles {:dev {:plugins      [[lein-codox "0.10.7"]]
-                   :dependencies [[lambdaisland/kaocha    "0.0-554"]
+  :profiles {:dev {:dependencies [[lambdaisland/kaocha    "0.0-554"]
                                   [org.clojure/test.check "0.10.0"]]
                    :pedantic?    :warn
-                   :aliases      {"kaocha" ["with-profile" "+dev" "run" "-m" "kaocha.runner"]}
-                   :codox        {:source-uri "https://github.com/exoscale/automata/blob/{version}/{filepath}#L{line}"
-                                  :doc-files  ["README.md"]
-                                  :metadata   {:doc/format "markdown"}}}})
+                   :aliases      {"kaocha" ["with-profile" "+dev" "run" "-m" "kaocha.runner"]}}})

--- a/src/automata/fsm.cljc
+++ b/src/automata/fsm.cljc
@@ -5,7 +5,9 @@
 
 (defn ^:no-doc extract
   [x k]
-  (cond (map? x) (get x k) (keyword? x) x))
+  (cond
+    (map? x) (get x k)
+    (keyword? x) x))
 
 (defn transit
   "Given a set of rules for states, a current state and event,
@@ -71,9 +73,9 @@
 ;; Specs
 ;; =====
 
-(s/def ::state       keyword?)
-(s/def ::action      keyword?)
-(s/def ::event       keyword?)
+(s/def ::state       qualified-keyword?)
+(s/def ::action      qualified-keyword?)
+(s/def ::event       qualified-keyword?)
 (s/def ::actions     (s/coll-of ::action))
 (s/def ::transition  (s/keys :req [::event ::to] :opt [::actions]))
 (s/def ::transitions (s/coll-of ::transition))

--- a/src/automata/fsm.cljc
+++ b/src/automata/fsm.cljc
@@ -73,6 +73,7 @@
 
 (s/def ::state       keyword?)
 (s/def ::action      keyword?)
+(s/def ::event       keyword?)
 (s/def ::actions     (s/coll-of ::action))
 (s/def ::transition  (s/keys :req [::event ::to] :opt [::actions]))
 (s/def ::transitions (s/coll-of ::transition))

--- a/src/automata/fsm.cljc
+++ b/src/automata/fsm.cljc
@@ -21,7 +21,7 @@
 
    Both arities throw when no possible transition was found"
   ([{::keys [rules state] :as machine} event]
-   (let [{::keys [actions to] :as _transition} (transit rules state event)]
+   (let [{::keys [actions to]} (transit rules state event)]
      (-> machine
          (dissoc ::actions)
          (assoc ::state to)

--- a/src/automata/view.cljc
+++ b/src/automata/view.cljc
@@ -4,7 +4,7 @@
 
 (defn identifier
   [x]
-  (str "\"" (name x) "\""))
+  (str \" (name x) \"))
 
 (defn ^:no-doc draw-transition
   "Single transition view builder"

--- a/src/automata/view.cljc
+++ b/src/automata/view.cljc
@@ -2,11 +2,15 @@
   "Simplistic visualization builder. Leaves calling
    graphviz tools up to the caller")
 
+(defn identifier
+  [x]
+  (format "\"%s\"" (name x)))
+
 (defn ^:no-doc draw-transition
   "Single transition view builder"
   [[state transitions]]
   (for [{:automata.fsm/keys [event to]} transitions]
-    (str (name state) " -> " (name to) " [label=\"" (name event) "\"];\n")))
+    (str (identifier state) " -> " (identifier to) " [label="(identifier event) "];\n")))
 
 (defn draw-fsm
   "Create a string which can later be fed to graphviz's dot"

--- a/src/automata/view.cljc
+++ b/src/automata/view.cljc
@@ -4,7 +4,7 @@
 
 (defn identifier
   [x]
-  (format "\"%s\"" (name x)))
+  (str "\"" (name x) "\""))
 
 (defn ^:no-doc draw-transition
   "Single transition view builder"

--- a/test/automata/fsm_test.clj
+++ b/test/automata/fsm_test.clj
@@ -16,24 +16,24 @@
         (= ::foo (fsm/extract {kw ::foo} kw)))))
 
 (def resource-rules
-  {:init     [{::fsm/event :create  ::fsm/to :creating ::fsm/actions [:create]}
-              {::fsm/event :kill    ::fsm/to :killed}]
-   :creating [{::fsm/event :created ::fsm/to :down}
-              {::fsm/event :error   ::fsm/to :init}]
-   :down     [{::fsm/event :start   ::fsm/to :starting ::fsm/actions [:start]}
-              {::fsm/event :kill    ::fsm/to :killing  ::fsm/actions [:kill]}]
-   :starting [{::fsm/event :started ::fsm/to :up}
-              {::fsm/event :error   ::fsm/to :down}]
-   :stopping [{::fsm/event :stopped ::fsm/to :down}
-              {::fsm/event :error   ::fsm/to :up}]
-   :up       [{::fsm/event :stop    ::fsm/to :stopping ::fsm/actions [:stop]}
-              {::fsm/event :kill    ::fsm/to :killing  ::fsm/actions [:kill]}]
-   :killing  [{::fsm/event :killed  ::fsm/to :killed}
-              {::fsm/event :error   ::fsm/to :killing}]
-   :killed   []})
+  {:state/init     [{::fsm/event :event/create  ::fsm/to :state/creating ::fsm/actions [:action/create]}
+                    {::fsm/event :event/kill    ::fsm/to :state/killed}]
+   :state/creating [{::fsm/event :event/created ::fsm/to :state/down}
+                    {::fsm/event :event/error   ::fsm/to :state/init}]
+   :state/down     [{::fsm/event :event/start   ::fsm/to :state/starting ::fsm/actions [:action/start]}
+                    {::fsm/event :event/kill    ::fsm/to :state/killing  ::fsm/actions [:action/kill]}]
+   :state/starting [{::fsm/event :event/started ::fsm/to :state/up}
+                    {::fsm/event :event/error   ::fsm/to :state/down}]
+   :state/stopping [{::fsm/event :event/stopped ::fsm/to :state/down}
+                    {::fsm/event :event/error   ::fsm/to :state/up}]
+   :state/up       [{::fsm/event :event/stop    ::fsm/to :state/stopping ::fsm/actions [:action/stop]}
+                    {::fsm/event :event/kill    ::fsm/to :state/killing  ::fsm/actions [:action/kill]}]
+   :state/killing  [{::fsm/event :event/killed  ::fsm/to :state/killed}
+                    {::fsm/event :event/error   ::fsm/to :state/killing}]
+   :state/killed   []})
 
 (def generator
-  (gen/let [[state transitions] (gen/elements (dissoc resource-rules :killed))
+  (gen/let [[state transitions] (gen/elements (dissoc resource-rules :state/killed))
             transition          (gen/elements transitions)]
     [state transition]))
 
@@ -49,8 +49,9 @@
 (deftest resource-transitions-test
   (= {::fsm/state :killed}
      (reduce fsm/transit
-             {::fsm/rules resource-rules ::fsm/state :init}
-             [:create :created :start :started :stop :stopped :kill :killed])))
+             {::fsm/rules resource-rules ::fsm/state :state/init}
+             [:event/create :event/created :event/start :event/started
+              :event/stop :event/stopped :event/kill :event/killed])))
 
 (comment
   (require '[automata.view :as v])


### PR DESCRIPTION
graphviz will complain about "-" otherwise

I also had some lingering changes from when I was playing with it back when you announced it, I added them here too. I can remove them if you prefer. 

* makes linters happy about unused binding
* slightly more efficient transitions, invalid-rules checking

