### PR TITLE
Don't use identical? for event comparison

### DIFF
--- a/src/automata/fsm.cljc
+++ b/src/automata/fsm.cljc
@@ -32,7 +32,7 @@
   ([rules state event]
    (let [transitions (get rules (extract state ::state))
          e           (extract event ::event)]
-     (or (reduce #(when (identical? (::event %2) e)
+     (or (reduce #(when (= (::event %2) e)
                     (reduced %2))
                  nil
                  transitions)


### PR DESCRIPTION
This is a situation where cljs is different than clj, and we probably want `=` anyway:

```
;; cljs
cljs.user=> (identical? :a :a)
false
cljs.user=> (= :a :a)
true
cljs.user=> 

;;;;
Clojure 1.11.1
(identical? :a :a)
true
(= :a :a)
true
user=> 
```